### PR TITLE
Only raise EtcdClusterIdChanged once on change

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2013 Jose Plana Mario
+Modifications, Copyright (c) 2015 Metaswitch Networks Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -68,6 +68,12 @@ class Client(object):
                                     etcd server in the cluster in the case the
                                     default one does not respond.
 
+            expected_cluster_id (str): If a string, recorded as the expected
+                                       UUID of the cluster (rather than
+                                       learning it from the first request),
+                                       reads will raise EtcdClusterIdChanged
+                                       if they receive a response with a
+                                       different cluster ID.
         """
         self._machines_cache = []
         self.expected_cluster_id = expected_cluster_id
@@ -87,6 +93,7 @@ class Client(object):
 
         self._base_uri = uri(self._protocol, self._host, self._port)
 
+        self.expected_cluster_id = expected_cluster_id
         self.version_prefix = version_prefix
 
         self._read_timeout = read_timeout
@@ -300,7 +307,7 @@ class Client(object):
 
         return self.write(obj.key, obj.value, **kwdargs)
 
-    def read(self, key, check_cluster_uuid=False, **kwdargs):
+    def read(self, key, **kwdargs):
         """
         Returns the value of the key 'key'.
 
@@ -346,7 +353,7 @@ class Client(object):
 
         response = self.api_execute(
             self.key_endpoint + key, self._MGET, params=params,
-            timeout=timeout, check_cluster_uuid=check_cluster_uuid)
+            timeout=timeout)
         return self._result_from_response(response)
 
     def delete(self, key, recursive=None, dir=None, **kwdargs):
@@ -587,22 +594,18 @@ class Client(object):
                 some_request_failed = True
 
             else:
-                # If requested, check the cluster ID hasn't changed under us.
+                # Check the cluster ID hasn't changed under us.
                 # We need preload_content == False above to ensure we can read
                 # the headers here before waiting for the content of a watch
                 # below.
                 cluster_id = response.getheader("x-etcd-cluster-id")
-                if (check_cluster_uuid and
-                        self.expected_cluster_id and
-                        (cluster_id != self.expected_cluster_id)):
-                    raise etcd.EtcdClusterIdChanged(
-                        'The UUID of the cluster changed from {} to '
-                        '{}.'.format(self.expected_cluster_id, cluster_id))
-                elif not self.expected_cluster_id:
+                if self.expected_cluster_id:
+                    if self.expected_cluster_id != cluster_id:
+                        raise etcd.EtcdClusterIdChanged(
+                            'The UUID of the cluster changed from {} to '
+                            '{}.'.format(self.expected_cluster_id, cluster_id))
+                else:
                     self.expected_cluster_id = cluster_id
-
-                # Force synchronous load of data before we return.
-                _ = response.data
 
         if some_request_failed:
             self._machines_cache = self.machines

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -594,18 +594,21 @@ class Client(object):
                 some_request_failed = True
 
             else:
-                # Check the cluster ID hasn't changed under us.
-                # We need preload_content == False above to ensure we can read
-                # the headers here before waiting for the content of a watch
-                # below.
+                # Check the cluster ID hasn't changed under us.  We use
+                # preload_content=False above so we can read the headers
+                # before we wait for the content of a long poll.
                 cluster_id = response.getheader("x-etcd-cluster-id")
-                if self.expected_cluster_id:
-                    if self.expected_cluster_id != cluster_id:
-                        raise etcd.EtcdClusterIdChanged(
-                            'The UUID of the cluster changed from {} to '
-                            '{}.'.format(self.expected_cluster_id, cluster_id))
-                else:
-                    self.expected_cluster_id = cluster_id
+                id_changed = (self.expected_cluster_id and
+                              cluster_id != self.expected_cluster_id)
+                # Update the ID so we only raise the exception once.
+                self.expected_cluster_id = cluster_id
+                if id_changed:
+                    # Defensive: clear the pool so that we connect afresh next
+                    # time.
+                    self.http.clear()
+                    raise etcd.EtcdClusterIdChanged(
+                        'The UUID of the cluster changed from {} to '
+                        '{}.'.format(self.expected_cluster_id, cluster_id))
 
         if some_request_failed:
             self._machines_cache = self.machines

--- a/src/etcd/tests/unit/test_old_request.py
+++ b/src/etcd/tests/unit/test_old_request.py
@@ -10,12 +10,18 @@ from etcd import EtcdException
 
 class FakeHTTPResponse(object):
 
-    def __init__(self, status, data=''):
+    def __init__(self, status, data='', headers=None):
         self.status = status
         self.data = data.encode('utf-8')
+        self.headers = headers or {
+            "x-etcd-cluster-id": "abdef12345",
+        }
 
     def getheaders(self):
-        return {}
+        return self.headers
+
+    def getheader(self, header):
+        return self.headers[header]
 
 class TestClientRequest(unittest.TestCase):
 

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -16,7 +16,7 @@ class TestClientApiBase(unittest.TestCase):
     def setUp(self):
         self.client = etcd.Client()
 
-    def _prepare_response(self, s, d):
+    def _prepare_response(self, s, d, cluster_id=None):
         if isinstance(d, dict):
             data = json.dumps(d).encode('utf-8')
         else:
@@ -25,10 +25,11 @@ class TestClientApiBase(unittest.TestCase):
         r = mock.create_autospec(urllib3.response.HTTPResponse)()
         r.status = s
         r.data = data
+        r.getheader.return_value = cluster_id or "abcd1234"
         return r
 
-    def _mock_api(self, status, d):
-        resp = self._prepare_response(status, d)
+    def _mock_api(self, status, d, cluster_id=None):
+        resp = self._prepare_response(status, d, cluster_id=cluster_id)
         self.client.api_execute = mock.create_autospec(
             self.client.api_execute, return_value=resp)
 
@@ -96,7 +97,6 @@ class TestClientApiInternals(TestClientApiBase):
         self.client.write('/newdir', None, dir=True)
         self.assertEquals(self.client.api_execute.call_args,
             (('/v2/keys/newdir', 'PUT'), dict(params={'dir': 'true'})))
-
 
 
 class TestClientApiInterface(TestClientApiBase):
@@ -438,10 +438,11 @@ class EtcdLockTestCase(TestClientApiBase):
 class TestClientRequest(TestClientApiInterface):
 
     def setUp(self):
-        self.client = etcd.Client()
+        self.client = etcd.Client(expected_cluster_id="abcdef1234")
 
-    def _mock_api(self, status, d):
+    def _mock_api(self, status, d, cluster_id=None):
         resp = self._prepare_response(status, d)
+        resp.getheader.return_value = cluster_id or "abcdef1234"
         self.client.http.request_encode_body = mock.create_autospec(
             self.client.http.request_encode_body, return_value=resp
         )
@@ -449,11 +450,13 @@ class TestClientRequest(TestClientApiInterface):
             self.client.http.request, return_value=resp
         )
 
-    def _mock_error(self, error_code, msg, cause, method='PUT', fields=None):
+    def _mock_error(self, error_code, msg, cause, method='PUT', fields=None,
+                    cluster_id=None):
         resp = self._prepare_response(
             500,
             {'errorCode': error_code, 'message': msg, 'cause': cause}
         )
+        resp.getheader.return_value = cluster_id or "abcdef1234"
         self.client.http.request_encode_body = mock.create_autospec(
             self.client.http.request_encode_body, return_value=resp
         )
@@ -482,6 +485,12 @@ class TestClientRequest(TestClientApiInterface):
         """ Exception will be raised if an unsupported HTTP method is used """
         self.assertRaises(etcd.EtcdException,
                           self.client.api_execute, '/testpath/bar', 'TRACE')
+
+    def test_read_cluster_id_changed(self):
+        """ Read timeout set to the default """
+        self._mock_api(200, {}, cluster_id="notabcd1234")
+        self.assertRaises(etcd.EtcdClusterIdChanged,
+                          self.client.read, '/testkey')
 
     def test_not_in(self):
         pass

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -488,9 +488,19 @@ class TestClientRequest(TestClientApiInterface):
 
     def test_read_cluster_id_changed(self):
         """ Read timeout set to the default """
-        self._mock_api(200, {}, cluster_id="notabcd1234")
+        d = {u'action': u'set',
+             u'node': {
+                u'expiration': u'2013-09-14T00:56:59.316195568+02:00',
+                u'modifiedIndex': 6,
+                u'key': u'/testkey',
+                u'ttl': 19,
+                u'value': u'test'
+                }
+             }
+        self._mock_api(200, d, cluster_id="notabcd1234")
         self.assertRaises(etcd.EtcdClusterIdChanged,
                           self.client.read, '/testkey')
+        self.client.read("/testkey")
 
     def test_not_in(self):
         pass


### PR DESCRIPTION
Removes the need for the reconnect in https://github.com/Metaswitch/calico/issues/556.

Backports the structure of the fix from the upstream-cluster-id-check branch, which I'm trying to get into the upstream project.  This includes fixing up the UT.
