### PR TITLE
Fix unhelpful log message when cluster ID changes

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -616,6 +616,7 @@ class Client(object):
         id_changed = (self.expected_cluster_id and
                       cluster_id != self.expected_cluster_id)
         # Update the ID so we only raise the exception once.
+        old_expected_cluster_id = self.expected_cluster_id
         self.expected_cluster_id = cluster_id
         if id_changed:
             # Defensive: clear the pool so that we connect afresh next
@@ -623,7 +624,7 @@ class Client(object):
             self.http.clear()
             raise etcd.EtcdClusterIdChanged(
                 'The UUID of the cluster changed from {} to '
-                '{}.'.format(self.expected_cluster_id, cluster_id))
+                '{}.'.format(old_expected_cluster_id, cluster_id))
 
     def _handle_server_response(self, response):
         """ Handles the server response """


### PR DESCRIPTION
When the cluster ID changes, python-etcd writes a log message of
the form

```
The UUID of the cluster changed from (expected) to (actual).
```

Since the expected cluster ID was overwritten with the actual value
immediately before this message was logged, the log message would
always use the same value in two places. This commit corrects the
message to use the correct value for (expected).

---

This is a mirror of [upstream PR #113](https://github.com/jplana/python-etcd/pull/113) for our fork.
