### PR TITLE
Add __version__ attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,8 +185,7 @@ Release HOWTO
 
 To make a release
 
-    1) Update release date/version in NEWS.txt, setup.py and
-       src/etcd/__init__.py
+    1) Update release date/version in NEWS.txt and setup.py
     2) Run 'python setup.py sdist'
     3) Test the generated source distribution in dist/
     4) Upload to PyPI: 'python setup.py sdist register upload'

--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,8 @@ Release HOWTO
 
 To make a release
 
-    1) Update release date/version in NEWS.txt and setup.py
+    1) Update release date/version in NEWS.txt, setup.py and
+       src/etcd/__init__.py
     2) Run 'python setup.py sdist'
     3) Test the generated source distribution in dist/
     4) Upload to PyPI: 'python setup.py sdist register upload'

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -3,6 +3,7 @@ from .client import Client
 from .lock import Lock
 from .election import LeaderElection
 
+__version__ = '0.3.3-calico-3'
 
 class EtcdResult(object):
     _node_props = {

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -1,9 +1,11 @@
 import collections
+import pkg_resources
+
 from .client import Client
 from .lock import Lock
 from .election import LeaderElection
 
-__version__ = '0.3.3-calico-3'
+__version__ = pkg_resources.get_distribution('python-etcd')
 
 class EtcdResult(object):
     _node_props = {


### PR DESCRIPTION
The module doesn't expose a `__version__` attribute, which is just a little bit tedious for debugging.
I haven't done much Python packaging, but this seems to be the simplest way of doing it.

Cory: please could you confirm that this is a sensible approach?
