### PR TITLE
Don't require urllib3 version < 1.8

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2013 Jose Plana Mario
+Modifications, Copyright (c) 2015 Metaswitch Networks Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,12 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.3.3'
+version = '0.3.3-calico-1'
 
 install_requires = [
-    'urllib3>=1.7',
+    # <1.8 because 1.8 changed exception hierarchy to include, at least,
+    # ProtocolError.
+    'urllib3>=1.7,<1.8',
     'pyOpenSSL>=0.14',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.3.3-calico-1'
+version = '0.3.3-calico-2'
 
 install_requires = [
     # <1.8 because 1.8 changed exception hierarchy to include, at least,

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,10 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.3.3-calico-3'
+version = '0.3.3-calico-4'
 
 install_requires = [
-    # <1.8 because 1.8 changed exception hierarchy to include, at least,
-    # ProtocolError.
-    'urllib3>=1.7,<1.8',
+    'urllib3>=1.7',
     'pyOpenSSL>=0.14',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.3.3-calico-2'
+version = '0.3.3-calico-3'
 
 install_requires = [
     # <1.8 because 1.8 changed exception hierarchy to include, at least,

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -110,6 +110,15 @@ class EtcdException(Exception):
         self.payload=payload
 
 
+class EtcdClusterIdChanged(EtcdException):
+    """
+    The etcd cluster ID changed.  This may indicate the cluster was replaced
+    with a backup.  Raised to prevent waiting on an etcd_index that was only
+    valid on the old cluster.
+    """
+    pass
+
+
 class EtcdKeyError(EtcdException):
     """
     Etcd Generic KeyError Exception

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -581,6 +581,11 @@ class Client(object):
                     raise etcd.EtcdException(
                         'HTTP method {} not supported'.format(method))
 
+            except urllib3.exceptions.MaxRetryError:
+                self._base_uri = self._next_server()
+                some_request_failed = True
+
+            else:
                 # If requested, check the cluster ID hasn't changed under us.
                 # We need preload_content == False above to ensure we can read
                 # the headers here before waiting for the content of a watch
@@ -597,10 +602,6 @@ class Client(object):
 
                 # Force synchronous load of data before we return.
                 _ = response.data
-
-            except urllib3.exceptions.MaxRetryError:
-                self._base_uri = self._next_server()
-                some_request_failed = True
 
         if some_request_failed:
             self._machines_cache = self.machines

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -68,6 +68,12 @@ class Client(object):
                                     etcd server in the cluster in the case the
                                     default one does not respond.
 
+            expected_cluster_id (str): If a string, recorded as the expected
+                                       UUID of the cluster (rather than
+                                       learning it from the first request),
+                                       reads will raise EtcdClusterIdChanged
+                                       if they receive a response with a
+                                       different cluster ID.
         """
         self._machines_cache = []
         self.expected_cluster_id = expected_cluster_id
@@ -87,6 +93,7 @@ class Client(object):
 
         self._base_uri = uri(self._protocol, self._host, self._port)
 
+        self.expected_cluster_id = expected_cluster_id
         self.version_prefix = version_prefix
 
         self._read_timeout = read_timeout
@@ -300,7 +307,7 @@ class Client(object):
 
         return self.write(obj.key, obj.value, **kwdargs)
 
-    def read(self, key, check_cluster_uuid=False, **kwdargs):
+    def read(self, key, **kwdargs):
         """
         Returns the value of the key 'key'.
 
@@ -346,7 +353,7 @@ class Client(object):
 
         response = self.api_execute(
             self.key_endpoint + key, self._MGET, params=params,
-            timeout=timeout, check_cluster_uuid=check_cluster_uuid)
+            timeout=timeout)
         return self._result_from_response(response)
 
     def delete(self, key, recursive=None, dir=None, **kwdargs):
@@ -587,22 +594,18 @@ class Client(object):
                 some_request_failed = True
 
             else:
-                # If requested, check the cluster ID hasn't changed under us.
+                # Check the cluster ID hasn't changed under us.
                 # We need preload_content == False above to ensure we can read
                 # the headers here before waiting for the content of a watch
                 # below.
                 cluster_id = response.getheader("x-etcd-cluster-id")
-                if (check_cluster_uuid and
-                        self.expected_cluster_id and
-                        (cluster_id != self.expected_cluster_id)):
-                    raise etcd.EtcdClusterIdChanged(
-                        'The UUID of the cluster changed from {} to '
-                        '{}.'.format(self.expected_cluster_id, cluster_id))
-                elif not self.expected_cluster_id:
+                if self.expected_cluster_id:
+                    if self.expected_cluster_id != cluster_id:
+                        raise etcd.EtcdClusterIdChanged(
+                            'The UUID of the cluster changed from {} to '
+                            '{}.'.format(self.expected_cluster_id, cluster_id))
+                else:
                     self.expected_cluster_id = cluster_id
-
-                # Force synchronous load of data before we return.
-                _ = response.data
 
         if some_request_failed:
             self._machines_cache = self.machines

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -616,6 +616,7 @@ class Client(object):
         id_changed = (self.expected_cluster_id and
                       cluster_id != self.expected_cluster_id)
         # Update the ID so we only raise the exception once.
+        old_expected_cluster_id = self.expected_cluster_id
         self.expected_cluster_id = cluster_id
         if id_changed:
             # Defensive: clear the pool so that we connect afresh next
@@ -623,7 +624,7 @@ class Client(object):
             self.http.clear()
             raise etcd.EtcdClusterIdChanged(
                 'The UUID of the cluster changed from {} to '
-                '{}.'.format(self.expected_cluster_id, cluster_id))
+                '{}.'.format(old_expected_cluster_id, cluster_id))
 
     def _handle_server_response(self, response):
         """ Handles the server response """

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -7,6 +7,7 @@
 
 """
 import urllib3
+import urllib3.util
 import json
 import ssl
 
@@ -68,6 +69,7 @@ class Client(object):
 
         """
         self._machines_cache = []
+        self._cluster_uuid = None
 
         self._protocol = protocol
 
@@ -297,9 +299,7 @@ class Client(object):
 
         return self.write(obj.key, obj.value, **kwdargs)
 
-
-
-    def read(self, key, **kwdargs):
+    def read(self, key, check_cluster_uuid=False, **kwdargs):
         """
         Returns the value of the key 'key'.
 
@@ -344,7 +344,8 @@ class Client(object):
         timeout = kwdargs.get('timeout', None)
 
         response = self.api_execute(
-            self.key_endpoint + key, self._MGET, params=params, timeout=timeout)
+            self.key_endpoint + key, self._MGET, params=params,
+            timeout=timeout, check_cluster_uuid=check_cluster_uuid)
         return self._result_from_response(response)
 
     def delete(self, key, recursive=None, dir=None, **kwdargs):
@@ -480,10 +481,10 @@ class Client(object):
         """
         if index:
             return self.read(key, wait=True, waitIndex=index, timeout=timeout,
-                             recursive=recursive)
+                             recursive=recursive, check_cluster_uuid=True)
         else:
             return self.read(key, wait=True, timeout=timeout,
-                             recursive=recursive)
+                             recursive=recursive, check_cluster_uuid=True)
 
     def eternal_watch(self, key, index=None):
         """
@@ -538,7 +539,8 @@ class Client(object):
         except IndexError:
             raise etcd.EtcdException('No more machines in the cluster')
 
-    def api_execute(self, path, method, params=None, timeout=None):
+    def api_execute(self, path, method, params=None, timeout=None,
+                    check_cluster_uuid=False):
         """ Executes the query. """
 
         some_request_failed = False
@@ -563,7 +565,8 @@ class Client(object):
                         url,
                         timeout=timeout,
                         fields=params,
-                        redirect=self.allow_redirect)
+                        redirect=self.allow_redirect,
+                        preload_content=False)
 
                 elif (method == self._MPUT) or (method == self._MPOST):
                     response = self.http.request_encode_body(
@@ -572,10 +575,28 @@ class Client(object):
                         fields=params,
                         timeout=timeout,
                         encode_multipart=False,
-                        redirect=self.allow_redirect)
+                        redirect=self.allow_redirect,
+                        preload_content=False)
                 else:
                     raise etcd.EtcdException(
                         'HTTP method {} not supported'.format(method))
+
+                # If requested, check the cluster ID hasn't changed under us.
+                # We need preload_content == False above to ensure we can read
+                # the headers here before waiting for the content of a watch
+                # below.
+                cluster_id = response.getheader("x-etcd-cluster-id")
+                if (check_cluster_uuid and
+                        self._cluster_uuid and
+                        (cluster_id != self._cluster_uuid)):
+                    raise etcd.EtcdClusterIdChanged(
+                        'The UUID of the cluster changed from {} to '
+                        '{}.'.format(self._cluster_uuid, cluster_id))
+                elif not self._cluster_uuid:
+                    self._cluster_uuid = cluster_id
+
+                # Force synchronous load of data before we return.
+                _ = response.data
 
             except urllib3.exceptions.MaxRetryError:
                 self._base_uri = self._next_server()

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -594,18 +594,21 @@ class Client(object):
                 some_request_failed = True
 
             else:
-                # Check the cluster ID hasn't changed under us.
-                # We need preload_content == False above to ensure we can read
-                # the headers here before waiting for the content of a watch
-                # below.
+                # Check the cluster ID hasn't changed under us.  We use
+                # preload_content=False above so we can read the headers
+                # before we wait for the content of a long poll.
                 cluster_id = response.getheader("x-etcd-cluster-id")
-                if self.expected_cluster_id:
-                    if self.expected_cluster_id != cluster_id:
-                        raise etcd.EtcdClusterIdChanged(
-                            'The UUID of the cluster changed from {} to '
-                            '{}.'.format(self.expected_cluster_id, cluster_id))
-                else:
-                    self.expected_cluster_id = cluster_id
+                id_changed = (self.expected_cluster_id and
+                              cluster_id != self.expected_cluster_id)
+                # Update the ID so we only raise the exception once.
+                self.expected_cluster_id = cluster_id
+                if id_changed:
+                    # Defensive: clear the pool so that we connect afresh next
+                    # time.
+                    self.http.clear()
+                    raise etcd.EtcdClusterIdChanged(
+                        'The UUID of the cluster changed from {} to '
+                        '{}.'.format(self.expected_cluster_id, cluster_id))
 
         if some_request_failed:
             self._machines_cache = self.machines

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -38,6 +38,7 @@ class Client(object):
             cert=None,
             ca_cert=None,
             allow_reconnect=False,
+            expected_cluster_id=None,
     ):
         """
         Initialize the client.
@@ -69,7 +70,7 @@ class Client(object):
 
         """
         self._machines_cache = []
-        self._cluster_uuid = None
+        self.expected_cluster_id = expected_cluster_id
 
         self._protocol = protocol
 
@@ -592,13 +593,13 @@ class Client(object):
                 # below.
                 cluster_id = response.getheader("x-etcd-cluster-id")
                 if (check_cluster_uuid and
-                        self._cluster_uuid and
-                        (cluster_id != self._cluster_uuid)):
+                        self.expected_cluster_id and
+                        (cluster_id != self.expected_cluster_id)):
                     raise etcd.EtcdClusterIdChanged(
                         'The UUID of the cluster changed from {} to '
-                        '{}.'.format(self._cluster_uuid, cluster_id))
-                elif not self._cluster_uuid:
-                    self._cluster_uuid = cluster_id
+                        '{}.'.format(self.expected_cluster_id, cluster_id))
+                elif not self.expected_cluster_id:
+                    self.expected_cluster_id = cluster_id
 
                 # Force synchronous load of data before we return.
                 _ = response.data

--- a/src/etcd/tests/unit/test_old_request.py
+++ b/src/etcd/tests/unit/test_old_request.py
@@ -10,12 +10,18 @@ from etcd import EtcdException
 
 class FakeHTTPResponse(object):
 
-    def __init__(self, status, data=''):
+    def __init__(self, status, data='', headers=None):
         self.status = status
         self.data = data.encode('utf-8')
+        self.headers = headers or {
+            "x-etcd-cluster-id": "abdef12345",
+        }
 
     def getheaders(self):
-        return {}
+        return self.headers
+
+    def getheader(self, header):
+        return self.headers[header]
 
 class TestClientRequest(unittest.TestCase):
 

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -16,7 +16,7 @@ class TestClientApiBase(unittest.TestCase):
     def setUp(self):
         self.client = etcd.Client()
 
-    def _prepare_response(self, s, d):
+    def _prepare_response(self, s, d, cluster_id=None):
         if isinstance(d, dict):
             data = json.dumps(d).encode('utf-8')
         else:
@@ -25,10 +25,11 @@ class TestClientApiBase(unittest.TestCase):
         r = mock.create_autospec(urllib3.response.HTTPResponse)()
         r.status = s
         r.data = data
+        r.getheader.return_value = cluster_id or "abcd1234"
         return r
 
-    def _mock_api(self, status, d):
-        resp = self._prepare_response(status, d)
+    def _mock_api(self, status, d, cluster_id=None):
+        resp = self._prepare_response(status, d, cluster_id=cluster_id)
         self.client.api_execute = mock.create_autospec(
             self.client.api_execute, return_value=resp)
 
@@ -96,7 +97,6 @@ class TestClientApiInternals(TestClientApiBase):
         self.client.write('/newdir', None, dir=True)
         self.assertEquals(self.client.api_execute.call_args,
             (('/v2/keys/newdir', 'PUT'), dict(params={'dir': 'true'})))
-
 
 
 class TestClientApiInterface(TestClientApiBase):
@@ -438,10 +438,11 @@ class EtcdLockTestCase(TestClientApiBase):
 class TestClientRequest(TestClientApiInterface):
 
     def setUp(self):
-        self.client = etcd.Client()
+        self.client = etcd.Client(expected_cluster_id="abcdef1234")
 
-    def _mock_api(self, status, d):
+    def _mock_api(self, status, d, cluster_id=None):
         resp = self._prepare_response(status, d)
+        resp.getheader.return_value = cluster_id or "abcdef1234"
         self.client.http.request_encode_body = mock.create_autospec(
             self.client.http.request_encode_body, return_value=resp
         )
@@ -449,11 +450,13 @@ class TestClientRequest(TestClientApiInterface):
             self.client.http.request, return_value=resp
         )
 
-    def _mock_error(self, error_code, msg, cause, method='PUT', fields=None):
+    def _mock_error(self, error_code, msg, cause, method='PUT', fields=None,
+                    cluster_id=None):
         resp = self._prepare_response(
             500,
             {'errorCode': error_code, 'message': msg, 'cause': cause}
         )
+        resp.getheader.return_value = cluster_id or "abcdef1234"
         self.client.http.request_encode_body = mock.create_autospec(
             self.client.http.request_encode_body, return_value=resp
         )
@@ -482,6 +485,12 @@ class TestClientRequest(TestClientApiInterface):
         """ Exception will be raised if an unsupported HTTP method is used """
         self.assertRaises(etcd.EtcdException,
                           self.client.api_execute, '/testpath/bar', 'TRACE')
+
+    def test_read_cluster_id_changed(self):
+        """ Read timeout set to the default """
+        self._mock_api(200, {}, cluster_id="notabcd1234")
+        self.assertRaises(etcd.EtcdClusterIdChanged,
+                          self.client.read, '/testkey')
 
     def test_not_in(self):
         pass

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -488,9 +488,19 @@ class TestClientRequest(TestClientApiInterface):
 
     def test_read_cluster_id_changed(self):
         """ Read timeout set to the default """
-        self._mock_api(200, {}, cluster_id="notabcd1234")
+        d = {u'action': u'set',
+             u'node': {
+                u'expiration': u'2013-09-14T00:56:59.316195568+02:00',
+                u'modifiedIndex': 6,
+                u'key': u'/testkey',
+                u'ttl': 19,
+                u'value': u'test'
+                }
+             }
+        self._mock_api(200, d, cluster_id="notabcd1234")
         self.assertRaises(etcd.EtcdClusterIdChanged,
                           self.client.read, '/testkey')
+        self.client.read("/testkey")
 
     def test_not_in(self):
         pass


### PR DESCRIPTION
This is needed for running Calico with the current OpenStack tip, because http://git.openstack.org/cgit/openstack/requirements/tree/global-requirements.txt has

```
urllib3>=1.8.3
```

This shows up particularly when using devstack, because Calico, python-etcd and OpenStack projects are all then installed from source.  But it might bite also with some pieces being package-installed - I don't know.

We had an issue for a while at https://github.com/Metaswitch/calico/issues/419, about lifting our version cap, but this was eventually closed because there was no clear reason for it.  But now it appears we do have a clear reason.  @fasaxc tells me that he expects that we may hit corner case issues when lifting this cap, but that the mainline should work - and indeed, my testing so far confirms that the mainline does work.  I guess it would be good to know more about those corner case issues, so we can devise a plan for addressing them.
